### PR TITLE
if condition to avoid double -J in FORTRANMODDIRPREFIX

### DIFF
--- a/src/SConstruct
+++ b/src/SConstruct
@@ -134,7 +134,9 @@ else:
   else:
     sanitize_flag = debug_flag + ''
 
-  env.Append(FORTRANMODDIRPREFIX = '-J')
+
+  if '-J' not in env['FORTRANMODDIRPREFIX']:
+    env.Append(FORTRANMODDIRPREFIX = '-J')
   
   fortran_libs = ['gfortran']
 


### PR DESCRIPTION
Hello, I tested installing with different versions of Scons, it seems to fail from version 3.0.3 onwards.
I added an if condition that checks whether "-J" has already been added. I tested it using different versions of Scons, from 3.0.0 to the latest (3.1.1).